### PR TITLE
Enable correct parallel benchmark feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ harness = false
 [[bench]]
 name = "parallel"
 harness = false
+required-features = ["parallel"]
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ let db = Database::parser()
 
 **Note**: Single-file parsing cannot be parallelized effectively due to BibTeX's structure requiring sequential processing of string definitions. Use `parse_files()` when processing multiple bibliography files for maximum performance.
 
+To run the included parallel benchmarks, ensure the `parallel` feature is enabled:
+
+```bash
+cargo bench --features parallel --bench parallel
+```
+
 ## Examples
 
 ### Query Entries


### PR DESCRIPTION
## Summary
- ensure parallel benchmarks are compiled with the `parallel` feature
- document how to run the benchmark with the feature enabled

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68487d78491c832bade8fe481892fa9f