### PR TITLE
Add development setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Agent Development Guidelines
+
+This document provides instructions for automated agents working on
+this repository. Follow these guidelines when creating commits and pull
+requests or modifying the codebase.
+
+## Commit Message Standards
+- Use **Conventional Commits** (<https://www.conventionalcommits.org>)
+  for all commit messages.
+- Begin the summary line with a type such as `feat`, `fix`, `docs`,
+  `chore`, etc.
+- Keep the summary line under 72 characters.
+- Provide a concise body when necessary to explain the change.
+
+## Commit Sequencing
+- Group related changes into separate atomic commits.
+- Run pre-commit checks (see below) before each commit.
+
+## Pull Request Guidelines
+- Title should be a short summary of the change.
+- Include a description with the following sections:
+  - **Summary** – what was changed and why.
+  - **Testing** – commands run and their results.
+  - **Notes** – any additional context (optional).
+- Ensure CI passes before requesting review.
+
+## Pre-commit Checks
+Run the following commands before committing:
+```
+cargo fmt -- --check
+cargo clippy -- -D warnings
+cargo test --all-features
+```
+
+## Versioning
+- Adhere to [Semantic Versioning](https://semver.org/).
+- Increment:
+  - **MAJOR** for breaking API changes,
+  - **MINOR** for new functionality in a backwards-compatible manner,
+  - **PATCH** for backwards-compatible bug fixes.
+- Update `CHANGELOG.md` for user facing changes.
+
+## CHANGELOG Maintenance
+- Use Keep a Changelog format with sections: `Added`, `Changed`,
+  `Deprecated`, `Removed`, `Fixed`, `Security`.
+- Add entries under the `Unreleased` heading in chronological order.
+
+## Testing Standards
+- Prefer unit tests in the `tests/` directory.
+- Ensure test names are descriptive.
+- Maintain high coverage for new features.
+
+## Documentation
+- Update `README.md` when public APIs or workflows change.
+- Keep inline code comments clear and concise.
+

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ match Database::parse(input) {
 - thiserror - Error handling
 - memchr - String searching
 
+## Development Setup
+
+Run `./setup-dev.sh` once with internet access to install the Rust toolchain,
+Python dependencies, and to fetch all Cargo crates. After it completes you can
+build and test the crate completely offline.
+
 ## License
 
 MIT license ([LICENSE](LICENSE))

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# setup-dev.sh - Provision development environment for bibtex-parser
+# This script installs toolchains and prefetches dependencies so that the
+# repository can be built and tested offline.
+# It should be run with network access.
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+echo "[1/6] Installing system packages via apt..."
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+    build-essential pkg-config git curl \
+    python3 python3-venv python3-pip \
+    valgrind linux-tools-common linux-tools-generic
+
+# Install rustup if needed
+if ! command -v rustup >/dev/null; then
+    echo "[2/6] Installing rustup..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.75.0
+    source "$HOME/.cargo/env"
+else
+    source "$HOME/.cargo/env"
+    rustup toolchain install 1.75.0
+fi
+
+# Use the toolchain specified in Cargo.toml
+rustup default 1.75.0
+rustup component add rustfmt clippy
+
+# Install additional cargo tools if not present
+if ! command -v cargo-tarpaulin >/dev/null; then
+    echo "[3/6] Installing cargo-tarpaulin..."
+    cargo install cargo-tarpaulin
+fi
+if ! command -v flamegraph >/dev/null; then
+    echo "[4/6] Installing flamegraph..."
+    cargo install flamegraph
+fi
+
+# Set up Python virtual environment
+if [ ! -d "$REPO_ROOT/.venv" ]; then
+    echo "[5/6] Creating Python virtual environment..."
+    python3 -m venv "$REPO_ROOT/.venv"
+fi
+source "$REPO_ROOT/.venv/bin/activate"
+pip install --upgrade pip
+pip install rich
+deactivate
+
+# Prefetch Rust dependencies
+echo "[6/6] Fetching Rust crates..."
+cd "$REPO_ROOT"
+cargo fetch
+
+# Build and test once to populate target directory
+cargo build --all-targets
+cargo test --all-features
+
+echo "\nDevelopment environment setup complete. You can now work offline."


### PR DESCRIPTION
## Summary
- add `setup-dev.sh` to provision Rust and Python tools
- document contribution rules in `AGENTS.md`
- mention the setup script in the README

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_6849470dd9ac832bb2f63a67e431ae6e